### PR TITLE
Subject: [PATCH] libvirt: storage: rbd: fix a bug in

### DIFF
--- a/0001-libvirt-storage-rbd-fix-a-bug-in-virStorageBackendRB.patch
+++ b/0001-libvirt-storage-rbd-fix-a-bug-in-virStorageBackendRB.patch
@@ -1,0 +1,95 @@
+From 7ac190b4aa0b3b0692b51fd51d9703e5ae0c1ac2 Mon Sep 17 00:00:00 2001
+From: Wang Songbo <songbo@yunshan.net.cn>
+Date: Tue, 2 Jun 2015 22:00:54 -0400
+Subject: [PATCH] libvirt: storage: rbd: fix a bug in
+ virStorageBackendRBDRefreshPool
+
+libvirt pool will become inactive after one client
+does vol.delete and the other does pool.refresh
+in the same pool simultaneously.
+
+The reason is that rbd_list and  rbd_open are not
+wrapped in an atomic operation, but two seperate
+operations. For example, two clients are operating
+in the same pool at the same time. One client does
+rbd_list, and got 10 rbd images, meanwhile, the
+other client deletes one of the rbd image. In this
+situation, when the first client does next operation,
+such as rbd_open , the command may fail, because the
+rbd image has been removed.
+---
+ src/storage/storage_backend_rbd.c | 51 +++++++++++++++++++++++++++++++++++++--
+ 1 file changed, 49 insertions(+), 2 deletions(-)
+
+diff --git a/src/storage/storage_backend_rbd.c b/src/storage/storage_backend_rbd.c
+index ae4bcb3..24fbc84 100644
+--- a/src/storage/storage_backend_rbd.c
++++ b/src/storage/storage_backend_rbd.c
+@@ -266,6 +266,46 @@ static int virStorageBackendRBDCloseRADOSConn(virStorageBackendRBDStatePtr ptr)
+     return ret;
+ }
+ 
++static int volStorageBackendRBDVolIsExist(char *volname, virStorageBackendRBDStatePtr ptr)
++{
++    int ret = -1;
++    char *name, *names = NULL;
++    size_t max_size = 1024;
++    int len = -1;
++
++    while (true) {
++        if (VIR_ALLOC_N(names, max_size) < 0)
++            goto cleanup;
++
++        len = rbd_list(ptr->ioctx, names, &max_size);
++        if (len >= 0)
++            break;
++        if (len != -ERANGE) {
++            VIR_WARN("%s", _("A problem occurred while listing RBD images"));
++            goto cleanup;
++        }
++        VIR_FREE(names);
++    }
++
++    for (name = names; name < names + max_size;) {
++
++        if (STREQ(name, ""))
++            break;
++
++        name += strlen(name) + 1;
++        if (STREQ(volname, name)) {
++            VIR_ERROR("RBD images '%s' is exist, but cannot open it", volname);
++            ret = -2;
++            break;
++        }
++    }
++    ret = 0;
++
++cleanup:
++    VIR_FREE(names);
++    return ret;
++}
++
+ static int volStorageBackendRBDRefreshVolInfo(virStorageVolDefPtr vol,
+                                               virStoragePoolObjPtr pool,
+                                               virStorageBackendRBDStatePtr ptr)
+@@ -276,8 +316,15 @@ static int volStorageBackendRBDRefreshVolInfo(virStorageVolDefPtr vol,
+ 
+     r = rbd_open(ptr->ioctx, vol->name, &image, NULL);
+     if (r < 0) {
+-        virReportSystemError(-r, _("failed to open the RBD image '%s'"),
+-                             vol->name);
++        VIR_DEBUG("failed to open RBD image '%s', check if it was still exist in its pool",\
++                  vol->name);
++        if (volStorageBackendRBDVolIsExist(vol->name, ptr) == 0) {
++            VIR_DEBUG("vol '%s' may be removed by the other rbd client", vol->name);
++            ret = 0;
++        } else {
++            virReportSystemError(-r, _("failed to open the RBD image '%s'"),
++                    vol->name);
++        }
+         return ret;
+     }
+ 
+-- 
+1.8.3.1
+


### PR DESCRIPTION
 virStorageBackendRBDRefreshPool

[bug 1227257]
libvirt pool will become inactive after one client
does vol.delete and the other does pool.refresh
in the same pool simultaneously.
